### PR TITLE
Fix Java 8 Compatibility and Bump Version to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.cloudutils4j</groupId>
     <artifactId>CloudUtils4J</artifactId>
-    <version>1.0.0-Stable</version>
+    <version>1.0.1-Stable</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -30,17 +30,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>6.2.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>6.2.10</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Closes:** #18 `Bug: Build Fails with UnsupportedClassVersionError in Java 8 Environment`

**What this PR does:**
* Removes the unused `spring-context` and `spring-beans` dependencies from the `pom.xml`.
* Bumps the project version from `1.0.0-Stable` to `1.0.1-Stable`.

**Why this change is necessary:**
The removed Spring dependencies (version 6.x) require a Java 17+ runtime. This created a critical conflict with the project's declared Java 8 target, causing an `UnsupportedClassVersionError` for any consumer application running on Java 8.

A dependency analysis (`mvn dependency:tree`) confirmed that these Spring libraries were not being used by any part of the `CloudUtils4J` codebase. Removing them resolves the version conflict, eliminates "dead weight" from the library, and ensures it is fully compatible with Java 8 as intended.

**How to test:**
1.  Run `mvn clean install` on this branch. The build should succeed.
2.  Import this new version (`1.0.1-Stable`) into a separate Maven project that is configured for Java 8.
3.  Instantiate and use any class from the `CloudUtils4J` library (e.g., `AwsSdkStorageOperations`).
4.  The application should now run successfully without any `UnsupportedClassVersionError`.